### PR TITLE
Make lib null safe

### DIFF
--- a/flutter_profile_picture.iml
+++ b/flutter_profile_picture.iml
@@ -9,11 +9,14 @@
       <excludeFolder url="file://$MODULE_DIR$/.idea" />
       <excludeFolder url="file://$MODULE_DIR$/.pub" />
       <excludeFolder url="file://$MODULE_DIR$/build" />
+      <excludeFolder url="file://$MODULE_DIR$/example/.pub" />
+      <excludeFolder url="file://$MODULE_DIR$/example/build" />
+      <excludeFolder url="file://$MODULE_DIR$/example/.dart_tool" />
     </content>
     <orderEntry type="jdk" jdkName="Android API 29 Platform" jdkType="Android SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="library" name="Dart Packages" level="project" />
     <orderEntry type="library" name="Dart SDK" level="project" />
     <orderEntry type="library" name="Flutter Plugins" level="project" />
+    <orderEntry type="library" name="Dart Packages" level="project" />
   </component>
 </module>

--- a/lib/extends/input_text.dart
+++ b/lib/extends/input_text.dart
@@ -1,7 +1,7 @@
 class InitialName {
   // @string name
-  // @int count (optional) to limit the number of letters that appear
-  static String parseName(String name, int count) {
+  // @int letterLimit (optional) to limit the number of letters that appear
+  static String parseName(String name, int? letterLimit) {
     // separate each word
     var parts = name.split(' ');
     var initial = '';
@@ -9,8 +9,8 @@ class InitialName {
     // check length
     if (parts.length > 1) {
       // check max limit
-      if (count != null) {
-        for (var i = 0; i < count; i++) {
+      if (letterLimit != null) {
+        for (var i = 0; i < letterLimit; i++) {
           // combine the first letters of each word
           initial += parts[i][0];
         }

--- a/lib/src/avatar.dart
+++ b/lib/src/avatar.dart
@@ -2,11 +2,11 @@ part of flutter_profile_picture;
 
 class Avatar extends StatelessWidget {
   const Avatar({
-    Key key,
-    @required this.radius,
-    @required this.name,
-    @required this.fontsize,
-    this.random,
+    Key? key,
+    required this.radius,
+    required this.name,
+    required this.fontsize,
+    this.random = false,
     this.count,
     this.img,
   }) : super(key: key);
@@ -15,8 +15,8 @@ class Avatar extends StatelessWidget {
   final String name;
   final double fontsize;
   final bool random;
-  final int count;
-  final String img;
+  final int? count;
+  final String? img;
 
   @override
   Widget build(BuildContext context) {
@@ -28,16 +28,16 @@ class Avatar extends StatelessWidget {
             count: count,
             fontsize: fontsize,
             random: random)
-        : WithImage(radius: radius, img: img);
+        : WithImage(radius: radius, img: img!);
   }
 }
 
 // if image available
 class WithImage extends StatelessWidget {
   const WithImage({
-    Key key,
-    @required this.radius,
-    @required this.img,
+    Key? key,
+    required this.radius,
+    required this.img,
   }) : super(key: key);
 
   final double radius;
@@ -59,17 +59,17 @@ class WithImage extends StatelessWidget {
 // if no image
 class NoImage extends StatelessWidget {
   const NoImage({
-    Key key,
-    @required this.radius,
-    @required this.name,
-    @required this.count,
-    @required this.fontsize,
-    @required this.random,
+    Key? key,
+    required this.radius,
+    required this.name,
+    required this.count,
+    required this.fontsize,
+    required this.random,
   }) : super(key: key);
 
   final double radius;
   final String name;
-  final int count;
+  final int? count;
   final double fontsize;
   final bool random;
 

--- a/lib/src/profile_picture.dart
+++ b/lib/src/profile_picture.dart
@@ -5,7 +5,7 @@ class ProfilePicture extends StatelessWidget {
 
   // role is optional
   // it will be displayed under name
-  final String role;
+  final String? role;
   final double radius;
   final double fontsize;
 
@@ -20,19 +20,19 @@ class ProfilePicture extends StatelessWidget {
   // count is optional
   // to limit how many prefix names are displayed.
 
-  final int count;
+  final int? count;
   // img is optional
   // if "not empty", the background color and initial name will change to image.
 
-  final String img;
+  final String? img;
   const ProfilePicture({
-    Key key,
-    @required this.name,
-    @required this.radius,
-    @required this.fontsize,
+    Key? key,
+    required this.name,
+    required this.radius,
+    required this.fontsize,
     this.role,
-    this.tooltip,
-    this.random,
+    this.tooltip = false,
+    this.random = false,
     this.count,
     this.img,
   }) : super(key: key);
@@ -46,7 +46,7 @@ class ProfilePicture extends StatelessWidget {
         // when the user clicks on the profile picture, a message will appear
         // check if role is empty or not
         // if not add \n to create a break row
-        message: role == '' ? name : name + '\n' + role,
+        message: role == '' || role == null ? name : name + '\n' + role!,
         //  thrown into the avatar class.
         child: Avatar(
           radius: radius,

--- a/lib/src/tooltip.dart
+++ b/lib/src/tooltip.dart
@@ -4,7 +4,7 @@ class MyTooltip extends StatelessWidget {
   final Widget child;
   final String message;
 
-  MyTooltip({@required this.message, @required this.child});
+  MyTooltip({required this.message, required this.child});
 
   @override
   Widget build(BuildContext context) {
@@ -57,10 +57,12 @@ class TooltipBorder extends ShapeBorder {
   EdgeInsetsGeometry get dimensions => EdgeInsets.only(bottom: arrowHeight);
 
   @override
-  Path getInnerPath(Rect rect, {TextDirection textDirection}) => null;
+  Path getInnerPath(Rect rect, {TextDirection? textDirection}) {
+      return Path();
+  }
 
   @override
-  Path getOuterPath(Rect rect, {TextDirection textDirection}) {
+  Path getOuterPath(Rect rect, {TextDirection? textDirection}) {
     rect = Rect.fromPoints(
         rect.topLeft, rect.bottomRight - Offset(0, arrowHeight));
     double x = arrowWidth, y = arrowHeight, r = 1 - arrowArc;
@@ -76,7 +78,7 @@ class TooltipBorder extends ShapeBorder {
 
 // set stroke color
   @override
-  void paint(Canvas canvas, Rect rect, {TextDirection textDirection}) {
+  void paint(Canvas canvas, Rect rect, {TextDirection? textDirection}) {
     Paint paint = new Paint()
       ..color = Colors.black
       ..style = PaintingStyle.stroke

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.2
 homepage: "https://github.com/adityadees/flutter_profile_picture"
 
 environment:
-  sdk: ">=2.7.0 <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.17.0"
 
 dependencies:


### PR DESCRIPTION
Upgrade sdk to 2.12.0 as a minimum - then fixed the compile issues where nullability is now a thing.

Mostly just letting intellij sort it out. The only thing that might be breaking is changing 

`Path getInnerPath(Rect rect, {TextDirection textDirection}) => null;` as null can't be returned there anymore. It now returns a default Path()